### PR TITLE
add support for app svc

### DIFF
--- a/azure-vote/Dockerfile-for-app-service
+++ b/azure-vote/Dockerfile-for-app-service
@@ -1,0 +1,23 @@
+FROM    tiangolo/uwsgi-nginx-flask:python3.6
+
+COPY sshd_config /etc/ssh/
+COPY app_init.supervisord.conf /etc/supervisor/conf.d
+
+RUN  mkdir -p /home/LogFiles \
+     && echo "root:Docker!" | chpasswd \
+     && echo "cd /home" >> /etc/bash.bashrc \
+     && apt update \
+     && apt install -y --no-install-recommends openssh-server vim curl wget tcptraceroute
+
+RUN  pip install redis
+
+EXPOSE 2222 80
+ 
+ADD     /azure-vote /app
+
+ENV PORT 80
+ENV PATH ${PATH}:/home/site/wwwroot
+
+# Supervisor will call into /opt/startup/init_container.sh
+# Also see: http://blog.trifork.com/2014/03/11/using-supervisor-with-docker-to-manage-processes-supporting-image-inheritance/
+CMD ["/usr/bin/supervisord"]

--- a/azure-vote/app_init.supervisord.conf
+++ b/azure-vote/app_init.supervisord.conf
@@ -1,0 +1,5 @@
+[program:sshd]
+command=service ssh start
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+user=root

--- a/azure-vote/azure-vote/main.py
+++ b/azure-vote/azure-vote/main.py
@@ -18,7 +18,12 @@ redis_server = os.environ['REDIS']
 
 # Redis Connection
 try:
-    r = redis.Redis(redis_server)
+    if "REDIS_PWD" in os.environ:
+        r = redis.Redis(host=redis_server,
+                        port=6379, 
+                        password=os.environ['REDIS_PWD'])
+    else:
+        r = redis.Redis(redis_server)
     r.ping()
 except redis.ConnectionError:
     exit('Failed to connect to Redis, terminating.')

--- a/azure-vote/sshd_config
+++ b/azure-vote/sshd_config
@@ -1,0 +1,15 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			2222
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes


### PR DESCRIPTION
Related to #13 
- add REDIS_PWD environment variable for Redis password in case Azure Redis cache is being used; when not present a connection is being made without password
- add Dockerfile which enables ssh with use for Web App for Containers and assigns port 80