### PR TITLE
need to use StrictRedis when redis has password set

### DIFF
--- a/azure-vote/azure-vote/main.py
+++ b/azure-vote/azure-vote/main.py
@@ -19,7 +19,7 @@ redis_server = os.environ['REDIS']
 # Redis Connection
 try:
     if "REDIS_PWD" in os.environ:
-        r = redis.Redis(host=redis_server,
+        r = redis.StrictRedis(host=redis_server,
                         port=6379, 
                         password=os.environ['REDIS_PWD'])
     else:


### PR DESCRIPTION
This is in connection with https://github.com/Azure-Samples/azure-voting-app-redis/issues/17 which fully explains the issue and why I changed from redis.Redis() to redis.StrictRedis() when REDIS_PWD environment variable is found.

I have not included my modified version of azure-vote-all-in-one-redis.yml in my pull request since that would break things unless the Docker image microsoft/azure-vote-front:redis-v1 were also updated with the modified code.