### PR TITLE
updated deployment api version

### DIFF
--- a/azure-vote-all-in-one-redis.yaml
+++ b/azure-vote-all-in-one-redis.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-back
@@ -28,7 +28,7 @@ spec:
   selector:
     app: azure-vote-back
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-front


### PR DESCRIPTION
apiVersion: apps/v1beta1 -> apiVersion: apps/v1
apps/v1beta1 is deprecated and is removed in Kubernetes v1.16