### PR TITLE
static might get included with wrong permissions for nginx

### DIFF
--- a/azure-vote/Dockerfile
+++ b/azure-vote/Dockerfile
@@ -1,3 +1,5 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.6
 RUN pip install redis
 ADD /azure-vote /app
+RUN chmod 755 /app /app/static && chmod 644 /app/static/*
+


### PR DESCRIPTION
If cloning to a Linux system with a `umask 022`, then `/app/static` in the nginx folder has incorrect permissions to be read by the web server.  The user would get a 403 on the `default.css` stylesheet.  This change forces permissions on static content to be correct when included into the container.