### PR TITLE
Update Deployment Object API Version

### DIFF
--- a/azure-vote-all-in-one-redis.yaml
+++ b/azure-vote-all-in-one-redis.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-back
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: azure-vote-back
   template:
     metadata:
       labels:
@@ -28,12 +31,15 @@ spec:
   selector:
     app: azure-vote-back
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-vote-front
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: azure-vote-front
   strategy:
     rollingUpdate:
       maxSurge: 1


### PR DESCRIPTION
Updated the Deployments to use 'apps/v1' the previous API version used in this manifest is removed in Kubernetes 1.16.