### PR TITLE
Updated deprecated beta.kubernetes.io/os tags

### DIFF
--- a/azure-vote-all-in-one-redis.yaml
+++ b/azure-vote-all-in-one-redis.yaml
@@ -13,7 +13,7 @@ spec:
         app: azure-vote-back
     spec:
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       containers:
       - name: azure-vote-back
         image: redis
@@ -51,7 +51,7 @@ spec:
         app: azure-vote-front
     spec:
       nodeSelector:
-        "beta.kubernetes.io/os": linux
+        "kubernetes.io/os": linux
       containers:
       - name: azure-vote-front
         image: microsoft/azure-vote-front:v1


### PR DESCRIPTION
Per [kubernetes.io/.../labels-annotations-taints/](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/) beta.kubernetes.io/os is deprecated. Updated tags to kubernetes.io/os