### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,4 +15,4 @@ services:
     environment:
       REDIS: azure-vote-back
     ports:
-        - "8080:80"
+        - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,4 +15,4 @@ services:
     environment:
       REDIS: azure-vote-back
     ports:
-        - "8080:8080"
+        - "80:80"


### PR DESCRIPTION
ACI does not support port mapping, so the source and target ports defined in the Compose file must be the same. https://docs.docker.com/cloud/aci-compose-features/#exposing-ports